### PR TITLE
Add clear screen option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ It is possible to hide some parts of output via env variable `MOCHA_REPORTER_OPT
 
 `hide-stats` - will hide stat
 
+`clear-screen` - will clear the screen on start
+
 `show-back-order` - will show fails in back order
 
 ## Command line usage
@@ -35,6 +37,8 @@ You need to set options in such format A=B,C=D.... Options are:
 `hide-titles` accepted values `true`|`false` - show/hide executed test/suites titles (default `false`)
 
 `hide-stats` accepted values `true`|`false` - show/hide executed tests statistic (default `false`)
+
+`clear-screen` accepted values `true`|`false` - clear the screen before executing tests (default `false`)
 
 `show-back-order` accepted values `true`|`false` - test fails shown in back order, so first fail will be at the bottom (default `true`)
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function parseEnvOptions(opts) {
 
   opts.hideTitles = ~v.indexOf('hide-titles');
   opts.hideStats = ~v.indexOf('hide-stats');
-  opts.hideStats = ~v.indexOf('hide-stats');
+  opts.clearScreen = ~v.indexOf('clear-screen');
 
   return opts;
 }
@@ -42,6 +42,9 @@ function parseMochaReporterOptions(opts, reporterOptions) {
 
   if('hide-stats' in reporterOptions)
     opts.hideStats = reporterOptions['hide-stats'] === 'true';
+
+  if('clear-screen' in reporterOptions)
+    opts.clearScreen = reporterOptions['clear-screen'] === 'true';
 
   if('stack-exclude' in reporterOptions)
     opts.stackExclude = reporterOptions['stack-exclude'];
@@ -86,6 +89,10 @@ function Reporter(runner, mochaOptions) {
 
   runner.on('start', function() {
     stats.start = new Date;
+    if(that.options.clearScreen) {
+      process.stdout.write('\u001b[2J'); // clear screen.
+      process.stdout.write('\u001b[1;3H'); // set cursor position.
+    }
   });
 
   runner.on('suite', function(suite) {


### PR DESCRIPTION
Add an option (`clear-screen`) to clear the screen before executing tests. This is inspired by Mocha's `min` reporter [1]. Useful in combination with Mocha's `--watch` parameter.

- [x] Add option (via environment variable or command line parameter) to `index.js`.
- [x] Update `README.md`.

Example command line usage:

~~~
$ mocha --reporter mocha-better-spec-reporter --reporter-options clear-screen=true,hide-stats=true
~~~

[1] https://github.com/mochajs/mocha/blob/v3.2.0/lib/reporters/min.js#L26-L29